### PR TITLE
docs: Add Joke section to README with bear computer joke

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ Settings lock once the game starts.
 ## Notes
 
 - Player count and names are saved in `localStorage` for convenience.
+
+## Joke
+
+Why don’t bears use computers?
+
+Because they’re afraid of the mouse.


### PR DESCRIPTION
Adds a new Joke section to the README after the Notes section, featuring a lighthearted quip: 

Why don’t bears use computers?
Because they’re afraid of the mouse.

This is a cosmetic documentation change and does not affect functionality.

https://cosine.sh/cosine/poke-the-bear/task/kpbh4va6yap7
https://cosine.sh/gh/CosineAI/poke-the-bear/pull/4
Author: Curtis Huang